### PR TITLE
make docs cooler and try to fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,6 @@ version: 2
 formats:
   - pdf
 
-sphinx:
-  configuration: docs/conf.py
-
 build:
   os: ubuntu-20.04
   tools:

--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ A coro based callback system for many to one IPC setups.
 `pip install zonis`
 
 See the [examples](https://github.com/Skelmis/Zonis/tree/master/exampleshttps://github.com/Skelmis/Zonis/tree/master/examples) for simple use cases.
+___
+## Build the docs locally
+
+If you want to build and run the docs locally using sphinx run
+```
+sphinx-autobuild -a docs docs/_build/html --watch zonis
+```
+this will build the docs and start a local server; additionally it will listed for changes to the source directory ``zonis`` and to the docs source directory ``docs/``.
+You can find the builded files at ``docs/_build``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+import sys
+import os
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -10,6 +13,7 @@ project = "Zonis"
 copyright = "2022, Skelmis"
 author = "Skelmis"
 
+sys.path.insert(0, os.path.abspath("../"))
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
@@ -17,14 +21,30 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.viewcode",
 ]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+autodoc_member_order = "bysource"
+autodoc_typehints = "signature"
+autodoc_class_signature = "separated"
+autodoc_preserve_defaults = True
+autoclass_content = "class"
 
+autodoc_default_options = {
+    "exclude-members": "__new__, __init__",
+    "show-inheritance": True,
+}
+
+# used to cross-reference stuff
+intersphinx_mapping = {
+    "py": ("https://docs.python.org/3", None),
+}
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
-html_static_path = ["_static"]
+#html_static_path = ["_static"]

--- a/docs/modules/client.rst
+++ b/docs/modules/client.rst
@@ -8,4 +8,3 @@ Client
 .. autoclass:: Client
     :members:
     :undoc-members:
-    :special-members: __init__

--- a/zonis/client/client.py
+++ b/zonis/client/client.py
@@ -49,6 +49,17 @@ def route(route_name: Optional[str] = None):
 
 
 class Client:
+    """
+    Parameters
+    ----------
+    reconnect_attempt_count: :class:`int`
+        The number of times that the :class:`Client` should
+        attempt to reconnect.
+    url: :class:`str`
+        Defaults to ``ws://localhost``.
+    port: Optional[:class:`int`]
+        The port that the :class:`Client` should use.
+    """
     def __init__(
         self,
         *,
@@ -58,7 +69,7 @@ class Client:
         identifier: str = "DEFAULT",
         secret_key: str = "",
         override_key: Optional[str] = None,
-    ):
+    ) -> None:
         url = f"{url}:{port}" if port else url
         url = (
             f"ws://{url}"
@@ -78,7 +89,7 @@ class Client:
         self.__task: Optional[asyncio.Task] = None
         self._instance_mapping: Dict[str, Any] = {}
 
-    def register_class_instance_for_routes(self, instance, *routes):
+    def register_class_instance_for_routes(self, instance, *routes) -> None:
         for r in routes:
             self._instance_mapping[r] = instance
 
@@ -93,7 +104,7 @@ class Client:
 
         return decorator
 
-    def load_routes(self):
+    def load_routes(self) -> None:
         global deferred_routes
         for k, v in deferred_routes.items():
             if k in self._routes:
@@ -102,7 +113,7 @@ class Client:
             self._routes[k] = v
         deferred_routes = {}
 
-    async def start(self):
+    async def start(self) -> None:
         self.load_routes()
         await exception_aware_scheduler(
             self._connect, retry_count=self._reconnect_attempt_count
@@ -113,7 +124,7 @@ class Client:
             self.identifier,
         )
 
-    async def close(self):
+    async def close(self) -> None:
         if self.__current_ws:
             try:
                 await self.__current_ws.close()
@@ -129,7 +140,7 @@ class Client:
         self._connection_future = asyncio.Future()
         log.info("Successfully closed the client")
 
-    async def _connect(self):
+    async def _connect(self) -> None:
         try:
             async with websockets.connect(self._url) as websocket:
                 self.__current_ws = websocket

--- a/zonis/server/server.py
+++ b/zonis/server/server.py
@@ -15,13 +15,22 @@ from zonis.packet import RequestPacket, IdentifyPacket
 
 
 class Server:
+    """
+    Parameters
+    ----------
+    using_fastapi_websockets: :class:`bool`
+        Defaults to ``False``.
+    override_key: Optional[:class:`str`]
+    secret_key: :class:`str`
+        Defaults to an emptry string.
+    """
     def __init__(
         self,
         *,
         using_fastapi_websockets: bool = False,
         override_key: Optional[str] = None,
         secret_key: str = "",
-    ):
+    ) -> None:
         self._connections = {}
         self._secret_key: str = secret_key
         self._override_key: Optional[str] = (
@@ -29,10 +38,10 @@ class Server:
         )
         self.using_fastapi_websockets: bool = using_fastapi_websockets
 
-    def disconnect(self, identifier: str):
+    def disconnect(self, identifier: str) -> None:
         self._connections.pop(identifier, None)
 
-    async def _send(self, content: str, conn):
+    async def _send(self, content: str, conn) -> None:
         if self.using_fastapi_websockets:
             await conn.send_text(content)
         else:


### PR DESCRIPTION
- adds some docstrings
- `__init__` and `__new__` methods are now ignored
- adds some new extensions to sphinx ("sphinx.ext.extlinks", "sphinx.ext.viewcode") to make things cooler
- fixed the build problem though i'm not sure if on readthedocs everything works well
- python objects mentioned in the docs (such as `:class:str`) are now hyperlinked (thanks to "sphinx.ext.extlinks" and the mapping on `conf.py` "intersphinx_mapping")

all the other changes are just "autodoc" configurations and addition of return type hints